### PR TITLE
Patch 4

### DIFF
--- a/portal.html
+++ b/portal.html
@@ -1956,7 +1956,7 @@
             <!DOCTYPE html>
             <html>
             <head>
-              <title>Calculator</title>
+              <title>The Void</title>
               <style>
                 body { margin: 0; padding: 0; overflow: hidden; background: #000; }
                 iframe { width: 100vw; height: 100vh; border: none; }

--- a/voidN64.html
+++ b/voidN64.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Void GBA</title>
+  <title>Void N64</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">

--- a/voidportal.html
+++ b/voidportal.html
@@ -519,7 +519,7 @@ h1{
         <img src="SNES.png" alt="Super Nintendo">
         <span>Super Nintendo</span>
       </a>
-      <a href="voidz64.html" class="console-btn" data-console="n64">
+      <a href="voidN64.html" class="console-btn" data-console="n64">
         <img src="N64.png" alt="Nintendo 64">
         <span>Nintendo 64</span>
       </a>


### PR DESCRIPTION
fixed issues: 
1: when on voidz64.html, page is incorrectly titled  "void GBA" ; retitled to void N64  
2: voidz64.html has typos, ; renamed file to voidN64.html
3: updated voidportal.html to account for voidN64.html name change
4: voidportal.html incorrectly titled calculator ; renamed to The Void